### PR TITLE
refactor: extract file selection logic into FileSelector class

### DIFF
--- a/QTCreator/2024_Research_MassifCheck/CMakeLists.txt
+++ b/QTCreator/2024_Research_MassifCheck/CMakeLists.txt
@@ -29,6 +29,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
 
         Snapshot.h
         Parser.h Parser.cpp
+        fileselector.h fileselector.cpp
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET 2024_Research_MassifCheck APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/QTCreator/2024_Research_MassifCheck/fileselector.cpp
+++ b/QTCreator/2024_Research_MassifCheck/fileselector.cpp
@@ -1,0 +1,76 @@
+#include "fileselector.h"
+
+FileSelector::FileSelector(QObject *parent)
+    : QObject{parent}
+{}
+
+void FileSelector::selectFile(QWidget* parent, Mode mode){
+    std::string description;
+    std::string fileType;
+    if ( mode == COMPILE){
+        description = "Open Source File";
+        fileType = "C++ Files (*.cpp)";
+    }
+    else if ( mode == BINARY){
+        description = "Open Binary File";
+        fileType = "Executable Files (*)";
+    }
+    else if (mode == OUTPUT) {
+        description = "Select Massif Output File";
+        fileType = "Massif Output Files (massif.out.*)";
+    }
+
+    filePath = QFileDialog::getOpenFileName(parent,
+                                            tr(description.c_str()),
+                                            QDir::homePath(),
+                                            tr(fileType.c_str()));
+
+    fileName = QFileInfo(filePath).fileName();
+
+    if ( mode == COMPILE){
+        outFileName = replaceCppWithOut(fileName);
+        outFilePath = getDirectoryPath(filePath);
+    }
+
+}
+
+QString FileSelector::convertWindowsPathToWsl(const QString& winPath) {
+    QFileInfo fileInfo(winPath);
+    QString absolutePath = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
+
+    if (!absolutePath.contains(":\\")) {
+        return QString();  // Not a Windows-style path
+    }
+
+    QString driveLetter = absolutePath.left(1).toLower();
+    QString pathWithoutDrive = absolutePath.mid(2); // skip "C:"
+    QString wslPath = "/mnt/" + driveLetter + pathWithoutDrive;
+    wslPath.replace("\\", "/"); // convert backslashes to slashes
+
+    return wslPath;
+}
+
+QString FileSelector::getDirectoryPath(QString filePath){
+    int lastSlash = filePath.lastIndexOf(fileName);
+
+    if (lastSlash != -1) {
+        return filePath.left(lastSlash);
+    }
+    return QString();
+}
+
+QString FileSelector::replaceCppWithOut(const QString fileName) {
+    if (fileName.endsWith(".cpp", Qt::CaseInsensitive)) {
+        return fileName.left(fileName.length() - 4) + ".out";
+    }
+    return fileName + ".out";
+}
+
+void FileSelector::clearFileSelection()
+{
+    fileName.clear();
+    filePath.clear();
+    outFileName.clear();
+    outFilePath.clear();
+}
+

--- a/QTCreator/2024_Research_MassifCheck/fileselector.h
+++ b/QTCreator/2024_Research_MassifCheck/fileselector.h
@@ -1,0 +1,40 @@
+#ifndef FILESELECTOR_H
+#define FILESELECTOR_H
+
+#include <QObject>
+#include <QFileDialog>
+#include <QProcess>
+#include <QDir>
+#include <QCoreApplication>
+#include <QMessageBox>
+#include <QRegularExpression>
+#include "ModeEnum.h"
+
+class FileSelector : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FileSelector(QObject *parent = nullptr);
+
+    inline QString getFileName() const { return this->fileName; };
+    inline QString getFilePath() const { return this->filePath; };
+    inline QString getOutFileName() const {return this->outFileName;};
+    inline QString getOutFilePath() const {return this->outFilePath;};
+
+
+    void selectFile(QWidget* parent, Mode mode);
+    QString convertWindowsPathToWsl(const QString& winPath);
+    QString getDirectoryPath(QString filePath);
+    QString replaceCppWithOut(const QString fileName);
+    void clearFileSelection();
+
+signals:
+
+private:
+    QString fileName;
+    QString filePath;
+    QString outFileName;
+    QString outFilePath;
+};
+
+#endif // FILESELECTOR_H

--- a/QTCreator/2024_Research_MassifCheck/mainwindow.cpp
+++ b/QTCreator/2024_Research_MassifCheck/mainwindow.cpp
@@ -7,20 +7,21 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
     , massifRunner(new MassifRunner)
+    , fileSelector(new FileSelector)
 {
     ui->setupUi(this);
-    QObject::connect(this,  &MainWindow::modeValudeChanged, massifRunner, &MassifRunner::setMode);
 }
 
 MainWindow::~MainWindow()
 {
     delete massifRunner;
+    delete fileSelector;
     delete ui;
 }
 
 void MainWindow::on_btLoadFile_clicked()
 {
-    massifRunner->selectFile(this);
+    fileSelector->selectFile(this, mode);
 
     // Just for debugging
     //QMessageBox msgBox;
@@ -31,36 +32,39 @@ void MainWindow::on_btLoadFile_clicked()
     //                "\n " + massifRunner->convertWindowsPathToWsl(massifRunner->getMassifFilesDir()));
     // msgBox.exec();
 
-    this->ui->leFileName->setText(massifRunner->getFileName());
+    this->ui->leFileName->setText(fileSelector->getFileName());
 }
 
 void MainWindow::on_rbCompile_toggled(bool checked){
     if (checked){
-        modeValudeChanged(COMPILE);
+        mode = COMPILE;
+        fileSelector->clearFileSelection();
         this->ui->leFileName->clear();
     }
 };
 
 void MainWindow::on_rbBinary_toggled(bool checked){
     if (checked){
-        modeValudeChanged(BINARY);
+        mode = BINARY;
+        fileSelector->clearFileSelection();
         this->ui->leFileName->clear();
     }
 };
 
 void MainWindow::on_rbOutput_toggled(bool checked){
     if (checked){
-        modeValudeChanged(OUTPUT);
+        mode = OUTPUT;
+        fileSelector->clearFileSelection();
         this->ui->leFileName->clear();
     }
 };
 
 void MainWindow::on_btExecute_clicked()
 {
-    if (massifRunner->getFilePath().isEmpty() || ui->leFileName->text().isEmpty()) {
+    if (fileSelector->getFilePath().isEmpty() || ui->leFileName->text().isEmpty()) {
         QMessageBox::warning(nullptr, "Warning", "No file selected.");
         return;
     }
-    massifRunner->runMassifCheck();
+    massifRunner->runMassifCheck(*fileSelector, mode);
 }
 

--- a/QTCreator/2024_Research_MassifCheck/mainwindow.h
+++ b/QTCreator/2024_Research_MassifCheck/mainwindow.h
@@ -3,6 +3,8 @@
 
 #include <QMainWindow>
 #include "massifrunner.h"
+#include "fileselector.h"
+#include "massifanalyzer.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -18,9 +20,6 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-signals:
-    void modeValudeChanged(Mode mode);
-
 private slots:
     void on_btLoadFile_clicked();
     void on_btExecute_clicked();
@@ -31,5 +30,7 @@ private slots:
 private:
     Ui::MainWindow *ui;
     MassifRunner *massifRunner;
+    FileSelector *fileSelector;
+    Mode mode = COMPILE;
 };
 #endif // MAINWINDOW_H

--- a/QTCreator/2024_Research_MassifCheck/massifanalyzer.cpp
+++ b/QTCreator/2024_Research_MassifCheck/massifanalyzer.cpp
@@ -1,7 +1,8 @@
 #include "massifanalyzer.h"
 #include <QDebug>
 
-MassifAnalyzer::MassifAnalyzer() {}
+MassifAnalyzer::MassifAnalyzer(){}
+
 
 bool MassifAnalyzer::isMemoryStabilized(const QVector<Snapshot>& snapshots, int currentIndex, int windowSize) {
     if (currentIndex < 0 || currentIndex + windowSize >= snapshots.size())

--- a/QTCreator/2024_Research_MassifCheck/massifanalyzer.h
+++ b/QTCreator/2024_Research_MassifCheck/massifanalyzer.h
@@ -4,6 +4,7 @@
 #include "snapshot.h"
 #include <QObject>
 #include <QVector>
+#include "snapshot.h"
 
 class MassifAnalyzer
 {
@@ -12,7 +13,6 @@ public:
 
     bool isMemoryStabilized(const QVector<Snapshot>& snapshots, int currentIndex, int windowSize = 3);
     void detectMemoryLeaks(const QVector<Snapshot>& snapshots);
-
 };
 
 #endif // MASSIFANALYZER_H

--- a/QTCreator/2024_Research_MassifCheck/massifrunner.cpp
+++ b/QTCreator/2024_Research_MassifCheck/massifrunner.cpp
@@ -1,7 +1,5 @@
 #include "massifrunner.h"
 #include <string>
-#include "parser.h"
-#include "massifanalyzer.h"
 #include <QDebug>
 
 MassifRunner::MassifRunner(QObject *parent)
@@ -11,37 +9,6 @@ MassifRunner::MassifRunner(QObject *parent)
 
 MassifRunner::~MassifRunner(){
     delete process;
-}
-
-
-void MassifRunner::selectFile(QWidget* parent){
-    std::string description;
-    std::string fileType;
-    if ( mode == COMPILE){
-        description = "Open Source File";
-        fileType = "C++ Files (*.cpp)";
-    }
-    else if ( mode == BINARY){
-        description = "Open Binary File";
-        fileType = "Executable Files (*)";
-    }
-    else if (mode == OUTPUT) {
-        description = "Select Massif Output File";
-        fileType = "Massif Output Files (massif.out.*)";
-    }
-
-    filePath = QFileDialog::getOpenFileName(parent,
-                                            tr(description.c_str()),
-                                            QDir::homePath(),
-                                            tr(fileType.c_str()));
-
-    fileName = QFileInfo(filePath).fileName();
-
-    if ( mode == COMPILE){
-        outFileName = replaceCppWithOut(fileName);
-        outFilePath = getDirectoryPath(filePath);
-    }
-
 }
 
 QString MassifRunner::convertWindowsPathToWsl(const QString& winPath) {
@@ -78,31 +45,15 @@ QString MassifRunner::getMassifFilesDir() {
     }
 }
 
-QString MassifRunner::replaceCppWithOut(const QString fileName) {
-    if (fileName.endsWith(".cpp", Qt::CaseInsensitive)) {
-        return fileName.left(fileName.length() - 4) + ".out";
-    }
-    return fileName + ".out";
-}
-
-QString MassifRunner::getDirectoryPath(QString filePath){
-    int lastSlash = filePath.lastIndexOf(fileName);
-
-    if (lastSlash != -1) {
-        return filePath.left(lastSlash);
-    }
-    return QString();
-}
-
-void MassifRunner::runMassifCheck(){
+void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
     args.clear();
 
     if ( mode == COMPILE ){
         addArg(QString::fromStdString("g++"));
         addArg(QString::fromStdString("-g"));
-        addArg(convertWindowsPathToWsl(getFilePath()));
+        addArg(convertWindowsPathToWsl(fileSelector.getFilePath()));
         addArg(QString::fromStdString("-o"));
-        addArg(convertWindowsPathToWsl(outFilePath + outFileName));
+        addArg(convertWindowsPathToWsl(fileSelector.getOutFilePath() + fileSelector.getOutFileName()));
         process->start("wsl", getArgs());
         process->waitForFinished();
         QMessageBox msgBox;
@@ -111,7 +62,7 @@ void MassifRunner::runMassifCheck(){
     }
     else if ( mode == BINARY){
         QString massifOut = convertWindowsPathToWsl(getNextMassifOutFilePath());
-        QString exePath = convertWindowsPathToWsl(getFilePath());
+        QString exePath = convertWindowsPathToWsl(fileSelector.getFilePath());
 
         // Komanda koja pokreće valgrind u WSL i čeka ENTER da zatvori terminal
         QString command = QString("valgrind --tool=massif --massif-out-file=%1 %2; echo '--- Done ---'; read")
@@ -127,13 +78,13 @@ void MassifRunner::runMassifCheck(){
         }
     }
     else if ( mode == OUTPUT){
-        runMassifOutputAnalysis();
+        runMassifOutputAnalysis(fileSelector);
     }
 }
 
-void MassifRunner::runMassifOutputAnalysis() {
+void MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {
     Parser parser;
-    auto [header, snapshots] = parser.parseMassifFile(filePath);
+    auto [header, snapshots] = parser.parseMassifFile(fileSelector.getFilePath());
 
     if (snapshots.isEmpty()) {
         QMessageBox::warning(nullptr, "Error", "No snapshots found in the file.");
@@ -167,11 +118,4 @@ QString MassifRunner::getNextMassifOutFilePath() {
     int nextIndex = maxIndex + 1;
     QString fileName = QString("massif.out.%1").arg(nextIndex);
     return getMassifFilesDir() + "/" + fileName;
-}
-
-void MassifRunner::clearFileSelection(){
-    fileName.clear();
-    filePath.clear();
-    outFileName.clear();
-    outFilePath.clear();
 }

--- a/QTCreator/2024_Research_MassifCheck/massifrunner.h
+++ b/QTCreator/2024_Research_MassifCheck/massifrunner.h
@@ -9,6 +9,9 @@
 #include <QMessageBox>
 #include <QRegularExpression>
 #include "ModeEnum.h"
+#include "Parser.h"
+#include "fileselector.h"
+#include "massifanalyzer.h"
 
 class MassifRunner : public QObject
 {
@@ -19,40 +22,19 @@ public:
 
     QProcess *process;
 
-    inline QString getFileName() { return this->fileName; };
-    inline QString getFilePath() { return this->filePath; };
-
     inline QStringList getArgs() {return this->args; };
     inline void addArg(QString arg) { args << arg; };
 
-
-
-    void selectFile(QWidget* parent);
     QString convertWindowsPathToWsl(const QString& winPath);
-    QString getDirectoryPath(QString filePath);
-    QString replaceCppWithOut(const QString fileName);
     QString getMassifFilesDir();
-    void runMassifCheck();
+    void runMassifCheck(FileSelector& fileSelector, Mode mode);
     QString getNextMassifOutFilePath();
-    void clearFileSelection();
 
 private:
     Mode mode = COMPILE;
 
-    QString fileName;
-    QString filePath;
-    QString outFileName;
-    QString outFilePath;
-
-
     QStringList args;
-    void runMassifOutputAnalysis();
-
-public slots:
-    void setMode(Mode mode) {
-        this->mode = mode;
-        clearFileSelection();
-    };
+    void runMassifOutputAnalysis(FileSelector& fileSelector);
 
 signals:
 };

--- a/massif_files/massif.out.4
+++ b/massif_files/massif.out.4
@@ -1,0 +1,75 @@
+desc: --massif-out-file=/mnt/c/Users/drlje/Desktop/2024_Research_MassifCheck/massif_files/massif.out.4
+cmd: /mnt/c/Users/drlje/Desktop/1.out
+time_unit: i
+#-----------
+snapshot=0
+#-----------
+time=0
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=1
+#-----------
+time=1928716
+mem_heap_B=73728
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=2
+#-----------
+time=1933961
+mem_heap_B=74752
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=3
+#-----------
+time=1941141
+mem_heap_B=474752
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=4
+#-----------
+time=1941288
+mem_heap_B=474752
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=peak
+n3: 474752 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
+ n0: 400000 0x109209: main (1.cpp:8)
+ n1: 73728 0x490D38E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+  n1: 73728 0x400571E: call_init.part.0 (dl-init.c:74)
+   n1: 73728 0x4005823: call_init (dl-init.c:120)
+    n1: 73728 0x4005823: _dl_init (dl-init.c:121)
+     n0: 73728 0x401F59F: ??? (in /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2)
+ n0: 1024 in 1 place, below massif's threshold (1.00%)
+#-----------
+snapshot=5
+#-----------
+time=1941288
+mem_heap_B=74752
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=6
+#-----------
+time=1952859
+mem_heap_B=1024
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=7
+#-----------
+time=1954039
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty

--- a/massif_files/massif.out.5
+++ b/massif_files/massif.out.5
@@ -1,0 +1,87 @@
+desc: --massif-out-file=/mnt/c/Users/drlje/Desktop/2024_Research_MassifCheck/massif_files/massif.out.5
+cmd: /mnt/c/Users/drlje/Desktop/2.out
+time_unit: i
+#-----------
+snapshot=0
+#-----------
+time=0
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=1
+#-----------
+time=1946057
+mem_heap_B=73728
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=2
+#-----------
+time=1951403
+mem_heap_B=74752
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=3
+#-----------
+time=1959945
+mem_heap_B=75776
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=4
+#-----------
+time=1982803
+mem_heap_B=75776
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=peak
+n2: 75776 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
+ n1: 73728 0x490D38E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+  n1: 73728 0x400571E: call_init.part.0 (dl-init.c:74)
+   n1: 73728 0x4005823: call_init (dl-init.c:120)
+    n1: 73728 0x4005823: _dl_init (dl-init.c:121)
+     n0: 73728 0x401F59F: ??? (in /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2)
+ n1: 2048 0x4B871B4: _IO_file_doallocate (filedoalloc.c:101)
+  n2: 2048 0x4B97523: _IO_doallocbuf (genops.c:347)
+   n1: 1024 0x4B94883: _IO_file_underflow@@GLIBC_2.2.5 (fileops.c:486)
+    n1: 1024 0x4B975D1: _IO_default_uflow (genops.c:362)
+     n1: 1024 0x497E1C8: __gnu_cxx::stdio_sync_filebuf<char, std::char_traits<char> >::underflow() (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+      n1: 1024 0x492C429: std::basic_istream<char, std::char_traits<char> >& std::getline<char, std::char_traits<char>, std::allocator<char> >(std::basic_istream<char, std::char_traits<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+       n0: 1024 0x1092BF: main (2.cpp:9)
+   n1: 1024 0x4B94F8F: _IO_file_overflow@@GLIBC_2.2.5 (fileops.c:745)
+    n1: 1024 0x4B95AAE: _IO_new_file_xsputn (fileops.c:1244)
+     n1: 1024 0x4B95AAE: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
+      n1: 1024 0x4B88A11: fwrite (iofwrite.c:39)
+       n1: 1024 0x49ACDC3: std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+        n1: 1024 0x49AD13B: std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+         n0: 1024 0x1092A9: main (2.cpp:8)
+#-----------
+snapshot=5
+#-----------
+time=1982803
+mem_heap_B=2048
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=6
+#-----------
+time=1983845
+mem_heap_B=1024
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=7
+#-----------
+time=1983879
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty

--- a/massif_files/massif.out.6
+++ b/massif_files/massif.out.6
@@ -1,0 +1,75 @@
+desc: --massif-out-file=/mnt/c/Users/drlje/Desktop/2024_Research_MassifCheck/massif_files/massif.out.6
+cmd: /mnt/c/Users/drlje/Desktop/1.out
+time_unit: i
+#-----------
+snapshot=0
+#-----------
+time=0
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=1
+#-----------
+time=1928716
+mem_heap_B=73728
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=2
+#-----------
+time=1933961
+mem_heap_B=74752
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=3
+#-----------
+time=1941141
+mem_heap_B=474752
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=4
+#-----------
+time=1941288
+mem_heap_B=474752
+mem_heap_extra_B=24
+mem_stacks_B=0
+heap_tree=peak
+n3: 474752 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
+ n0: 400000 0x109209: main (1.cpp:8)
+ n1: 73728 0x490D38E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
+  n1: 73728 0x400571E: call_init.part.0 (dl-init.c:74)
+   n1: 73728 0x4005823: call_init (dl-init.c:120)
+    n1: 73728 0x4005823: _dl_init (dl-init.c:121)
+     n0: 73728 0x401F59F: ??? (in /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2)
+ n0: 1024 in 1 place, below massif's threshold (1.00%)
+#-----------
+snapshot=5
+#-----------
+time=1941288
+mem_heap_B=74752
+mem_heap_extra_B=16
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=6
+#-----------
+time=1952859
+mem_heap_B=1024
+mem_heap_extra_B=8
+mem_stacks_B=0
+heap_tree=empty
+#-----------
+snapshot=7
+#-----------
+time=1954039
+mem_heap_B=0
+mem_heap_extra_B=0
+mem_stacks_B=0
+heap_tree=empty


### PR DESCRIPTION
This PR addresses issue #12.

Summary:
- Introduced a new `FileSelector` class to encapsulate all file selection logic.
- `MainWindow` now delegates file choosing operations to `FileSelector`, improving separation of concerns.
- This change prepares the codebase for further modularization by isolating file-related responsibilities from the main application logic.

Please review when you have time. Let me know if any changes are needed.