### PR TITLE
Feature: C/C++ compiler detection and output file naming

### DIFF
--- a/QT_Massif_App/fileselector.cpp
+++ b/QT_Massif_App/fileselector.cpp
@@ -9,7 +9,7 @@ void FileSelector::selectFile(QWidget* parent, Mode mode){
     std::string fileType;
     if ( mode == COMPILE){
         description = "Open Source File";
-        fileType = "C++ Files (*.cpp)";
+        fileType = "C/C++ Files (*.c *.cpp)";
     }
     else if ( mode == BINARY){
         description = "Open Binary File";
@@ -28,7 +28,7 @@ void FileSelector::selectFile(QWidget* parent, Mode mode){
     fileName = QFileInfo(filePath).fileName();
 
     if ( mode == COMPILE){
-        outFileName = replaceCppWithOut(fileName);
+        outFileName = makeOutFIleName(fileName);
         outFilePath = getDirectoryPath(filePath);
     }
 
@@ -59,9 +59,12 @@ QString FileSelector::getDirectoryPath(QString filePath){
     return QString();
 }
 
-QString FileSelector::replaceCppWithOut(const QString fileName) {
+QString FileSelector::makeOutFIleName(const QString fileName) {
     if (fileName.endsWith(".cpp", Qt::CaseInsensitive)) {
         return fileName.left(fileName.length() - 4) + ".out";
+    }
+    else if (fileName.endsWith(".c", Qt::CaseInsensitive)){
+        return fileName.left(fileName.length() - 2) + ".out";
     }
     return fileName + ".out";
 }
@@ -80,7 +83,7 @@ void FileSelector::setFileFromPath(const QString& path, Mode mode)
     fileName = QFileInfo(path).fileName();
 
     if (mode == COMPILE) {
-        outFileName = replaceCppWithOut(fileName);
+        outFileName = makeOutFIleName(fileName);
         outFilePath = getDirectoryPath(filePath);
     }
 }

--- a/QT_Massif_App/fileselector.h
+++ b/QT_Massif_App/fileselector.h
@@ -25,7 +25,7 @@ public:
     void selectFile(QWidget* parent, Mode mode);
     QString convertWindowsPathToWsl(const QString& winPath);
     QString getDirectoryPath(QString filePath);
-    QString replaceCppWithOut(const QString fileName);
+    QString makeOutFIleName(const QString fileName);
     void clearFileSelection();
     void setFileFromPath(const QString& path, Mode mode);
 

--- a/QT_Massif_App/mainwindow.ui
+++ b/QT_Massif_App/mainwindow.ui
@@ -141,7 +141,7 @@
       <rect>
        <x>20</x>
        <y>34</y>
-       <width>383</width>
+       <width>403</width>
        <height>75</height>
       </rect>
      </property>
@@ -149,7 +149,7 @@
       <item>
        <widget class="QRadioButton" name="rbCompile">
         <property name="text">
-         <string>Compile C++ source file and run massif</string>
+         <string>Compile C/C++ source file and run massif</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -293,7 +293,7 @@
      <x>0</x>
      <y>0</y>
      <width>552</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
   </widget>

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -54,7 +54,12 @@ void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
     args.clear();
 
     if ( mode == COMPILE ){
-        addArg(QString::fromStdString("g++"));
+        if (fileSelector.getFileName().endsWith(".cpp")){
+            addArg(QString::fromStdString("g++"));
+        }
+        else {
+            addArg(QString::fromStdString("gcc"));
+        }
         addArg(QString::fromStdString("-g"));
         addArg(convertWindowsPathToWsl(fileSelector.getFilePath()));
         addArg(QString::fromStdString("-o"));

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # 2024_Research_MassifCheck
-Qt desktop application for running and analyzing Valgrind Massif heap memory profiling output.
+**Qt** desktop application for running and analyzing **Valgrind Massif** heap memory profiling output.
 
 ---
 
 ## ✨ Current Features
 
-- Select a C++ source file (.cpp) to automatically compile it and analyze with Valgrind Massif
+- Select a ``C`` or ``C++`` source file (.c or .cpp) to automatically compile it and analyze with Valgrind Massif
 - Select a compiled binary to analyze
 - Run Valgrind's Massif tool with custom options
 - Parse Massif output
@@ -13,12 +13,13 @@ Qt desktop application for running and analyzing Valgrind Massif heap memory pro
 
 ---
 
-## ## 🚀 Getting Started
+## 🚀 Getting Started
 ### 1. Prerequisites
 
 - [Qt Creator](https://www.qt.io/download) (6.0+)
 - WSL (Windows Subsystem for Linux)
 - Ubuntu distribution inside WSL
+- `g++` and `gcc` compilers installed inside WSL
 - Valgrind installed in WSL
 
 ---
@@ -61,7 +62,25 @@ Then set Ubuntu as default:
 wsl --set-default Ubuntu-22.04
 ```
 
-#### c. Install Valgrind in Ubuntu
+#### c. Install build-essential tools in Ubuntu
+
+Open powershell and launch wsl
+
+```powershell
+wsl
+```
+
+Then inside wsl run 
+
+```powershell
+sudo apt update
+sudo apt install build-essential
+```
+
+The `build-essential` package includes `gcc`, `g++`, and other tools required for compiling C/C++ programs.
+
+
+#### d. Install Valgrind in Ubuntu
 
 Open powershell and launch wsl
 
@@ -86,7 +105,7 @@ valgrind --version
 
 ## 🛠️ Building the Project
 
-- Open massif-visual-analyzer.pro in Qt Creator
+- Open the project folder containing `CMakeLists.txt` in Qt Creator
 
 - Configure with a Desktop kit
 


### PR DESCRIPTION
This PR improves the compilation process by adding automatic detection for C and C++ source files.

- Renamed function `FileSelector::replaceCppWithOut(const QString fileName)` to `FileSelector::makeOutFileName(const QString fileName)` to better reflect its functionality.
- The `makeOutFileName` function now checks if the input file ends with `.cpp` or `.c`. It removes that suffix and appends `.out` to generate the output filename.
  
- In `massifRunner::runMassifCheck`, when `mode == Compile`, the code inspects the file extension (`.cpp` or `.c`) and selects the appropriate compiler:
  - `.cpp` files use `g++`
  - `.c` files use `gcc`
  
  This compiler selection is then passed to `QProcess` for execution.

This change ensures the program compiles C and C++ files correctly, improving flexibility and automation.
