### PR TITLE
Feature/compile and run massif

### DIFF
--- a/QT_Massif_App/fileselector.h
+++ b/QT_Massif_App/fileselector.h
@@ -18,6 +18,8 @@ public:
 
     inline QString getFileName() const { return this->fileName; };
     inline QString getFilePath() const { return this->filePath; };
+    inline void setFileName(QString name) { fileName = name; }
+    inline void setFilePath(QString path) { filePath = path; }
     inline QString getOutFileName() const {return this->outFileName;};
     inline QString getOutFilePath() const {return this->outFilePath;};
 

--- a/QT_Massif_App/mainwindow.cpp
+++ b/QT_Massif_App/mainwindow.cpp
@@ -60,13 +60,10 @@ void MainWindow::on_btExecute_clicked()
     }
 
     QString newMassifFilePath = massifRunner->getNextMassifOutFilePath();
-    massifRunner->runMassifCheck(*fileSelector, mode);
-
-    // this if is a temporary solution until automatic compilation is developed (not only for binary)
-    // should also refactor the runMassifCheck function so that it returns boolean = true if successful, so that can also be checked in the if
-
-    massifSelector->setFileFromPath(newMassifFilePath, OUTPUT);
-    this->ui->leSelectedMassifOutFile->setText(QFileInfo(newMassifFilePath).fileName());
+    if ( massifRunner->runMassifCheck(*fileSelector, mode) ){
+        massifSelector->setFileFromPath(newMassifFilePath, OUTPUT);
+        this->ui->leSelectedMassifOutFile->setText(QFileInfo(newMassifFilePath).fileName());
+    }
 
 }
 

--- a/QT_Massif_App/mainwindow.cpp
+++ b/QT_Massif_App/mainwindow.cpp
@@ -64,10 +64,9 @@ void MainWindow::on_btExecute_clicked()
 
     // this if is a temporary solution until automatic compilation is developed (not only for binary)
     // should also refactor the runMassifCheck function so that it returns boolean = true if successful, so that can also be checked in the if
-    if(mode == BINARY){
-        massifSelector->setFileFromPath(newMassifFilePath, OUTPUT);
-        this->ui->leSelectedMassifOutFile->setText(QFileInfo(newMassifFilePath).fileName());
-    }
+
+    massifSelector->setFileFromPath(newMassifFilePath, OUTPUT);
+    this->ui->leSelectedMassifOutFile->setText(QFileInfo(newMassifFilePath).fileName());
 
 }
 

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -69,8 +69,12 @@ void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
         QMessageBox msgBox;
         msgBox.setText("Compile finished!");
         msgBox.exec();
+
+        fileSelector.setFileName(fileSelector.getOutFileName());
+        fileSelector.setFilePath(fileSelector.getOutFilePath() + fileSelector.getOutFileName());
+        mode = BINARY;
     }
-    else if ( mode == BINARY){
+    if ( mode == BINARY){
         QString massifOut = convertWindowsPathToWsl(getNextMassifOutFilePath());
         QString exePath = convertWindowsPathToWsl(fileSelector.getFilePath());
 

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -50,7 +50,7 @@ QString MassifRunner::getMassifFilesDir() {
     return massifPath;
 }
 
-void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
+bool MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
     args.clear();
 
     if ( mode == COMPILE ){
@@ -89,8 +89,11 @@ void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
         bool started = QProcess::startDetached("cmd.exe", args);
         if (!started) {
             QMessageBox::warning(nullptr, "Error", "Failed to launch Valgrind in terminal.");
+            return false;
         }
     }
+
+    return true;
 }
 
 QString MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {

--- a/QT_Massif_App/massifrunner.h
+++ b/QT_Massif_App/massifrunner.h
@@ -30,7 +30,7 @@ public:
 
     QString convertWindowsPathToWsl(const QString& winPath);
     QString getMassifFilesDir();
-    void runMassifCheck(FileSelector& fileSelector, Mode mode);
+    bool runMassifCheck(FileSelector& fileSelector, Mode mode);
     QString getNextMassifOutFilePath();
     void setMassifOptions(MassifOptions* options);
     QString runMassifOutputAnalysis(FileSelector& fileSelector);


### PR DESCRIPTION
This pull request improves the workflow for running Massif by:

- Merging the **"Compile"** and **"Run Massif"** actions into a single unified action that:
  - First compiles the code
  - If successful, automatically launches Massif profiling
- Changing `runMassifCheck` to return a `bool` instead of `void`, enabling the application to check whether Massif ran successfully
- Automatically setting the generated `massif.out` file in the **line edit** field after a successful run,
  so the user can manually trigger parsing by clicking **"Show Results"**

These changes streamline the user experience and ensure better integration between the build and profiling steps.