### PR TITLE
Feature/massif detailed analysis

### DIFF
--- a/.github/workflows/check-test-files.yml
+++ b/.github/workflows/check-test-files.yml
@@ -1,0 +1,34 @@
+name: Verify test files on Linux runner
+
+on: [push, pull_request]
+
+jobs:
+  check-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check all test files listed in run_massif_on_tests.sh
+        run: |
+          echo "🔍 Listing all test files in ./test/:"
+          test_files=$(find ./test -maxdepth 1 -type f \( -name 'test*.c' -o -name 'test*.cpp' \) -exec basename {} \;)
+          echo "$test_files"
+
+          echo "🔍 Extracting TEST_FILES array from run_massif_on_tests.sh..."
+          array_line=$(grep -oP 'TEST_FILES=\(\K[^\)]+' ./run_massif_on_tests.sh)
+          echo "$array_line"
+
+          missing=0
+          for f in $test_files; do
+            if ! echo "$array_line" | grep -qw "$f"; then
+              echo "❌ File '$f' is NOT listed in TEST_FILES array in run_massif_on_tests.sh"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -eq 1 ]; then
+            echo "❌ Some test files are missing from the TEST_FILES array!"
+            exit 1
+          else
+            echo "✅ All test files are properly listed in TEST_FILES array."
+          fi

--- a/QT_Massif_App/AllocationEntry.h
+++ b/QT_Massif_App/AllocationEntry.h
@@ -1,0 +1,14 @@
+#ifndef ALLOCATIONENTRY_H
+#define ALLOCATIONENTRY_H
+
+#include <QString>
+
+struct AllocationEntry
+{
+    qint64 bytes;
+    QString function;
+    QString sourceFile;
+    int line;
+};
+
+#endif // ALLOCATIONENTRY_H

--- a/QT_Massif_App/CMakeLists.txt
+++ b/QT_Massif_App/CMakeLists.txt
@@ -36,6 +36,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         fileselector.h fileselector.cpp
         resultdialog.h resultdialog.cpp resultdialog.ui
         AllocationEntry.h
+        functionallocsummary.h
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET QT_Massif_App APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/QT_Massif_App/CMakeLists.txt
+++ b/QT_Massif_App/CMakeLists.txt
@@ -20,6 +20,8 @@ set(PROJECT_SOURCES
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    find_package(Qt6 REQUIRED COMPONENTS Core)
+
     qt_add_executable(QT_Massif_App
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
@@ -37,6 +39,9 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         resultdialog.h resultdialog.cpp resultdialog.ui
         AllocationEntry.h
         functionallocsummary.h
+        massifanalyzerthresholds.h massifanalyzerthresholds.cpp
+        massifanalyzerthresholdswindow.h massifanalyzerthresholdswindow.cpp massifanalyzerthresholdswindow.ui
+
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET QT_Massif_App APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
@@ -57,6 +62,7 @@ else()
 endif()
 
 target_link_libraries(QT_Massif_App PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(QT_Massif_App PRIVATE Qt6::Core)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an

--- a/QT_Massif_App/CMakeLists.txt
+++ b/QT_Massif_App/CMakeLists.txt
@@ -35,6 +35,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         TimeUnit.h
         fileselector.h fileselector.cpp
         resultdialog.h resultdialog.cpp resultdialog.ui
+        AllocationEntry.h
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET QT_Massif_App APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/QT_Massif_App/MassifAnalyzerThresholds.h
+++ b/QT_Massif_App/MassifAnalyzerThresholds.h
@@ -1,0 +1,27 @@
+#ifndef MASSIFANALYZERTHRESHOLDS_H
+#define MASSIFANALYZERTHRESHOLDS_H
+
+#include <QObject>
+
+const qint64 BYTES_TO_MB = 1024 * 1024;
+
+class MassifAnalyzerThresholds : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MassifAnalyzerThresholds(QObject *parent = nullptr);
+    MassifAnalyzerThresholds(QObject *parent, MassifAnalyzerThresholds *thresholds);
+
+    qint64 highMemoryThreshold = 100 * 1024 * 1024;        // 100 MB
+    int highAllocationCount = 10;
+    qint64 smallTotalAllocation = 5 * 1024 * 1024;         // 5 MB
+    double memoryJumpThreshold = 0.5;                      // 50%
+    qint64 largeMemoryThreshold = 1000000000;              // 1 GB
+    qint64 memoryFreeThreshold = 4 * 1024;                 // 4 KB
+    double fragmentationThreshold = 0.10;                  // 10%
+
+    void setThresholds(MassifAnalyzerThresholds *thresholds);
+
+};
+
+#endif // MASSIFANALYZERTHRESHOLDS_H

--- a/QT_Massif_App/Parser.cpp
+++ b/QT_Massif_App/Parser.cpp
@@ -3,6 +3,7 @@
 #include <QTextStream>
 #include <QRegularExpression>
 #include <QDebug>
+#include <iostream>
 
 Parser::Parser() {}
 
@@ -21,14 +22,49 @@ std::pair<QMap<QString, QString>, QVector<Snapshot>> Parser::parseMassifFile(con
     QRegularExpression headerRegex(R"((\w+):\s*(.+))");
     QRegularExpression snapshotRegex(R"(snapshot=(\d+))");
     QRegularExpression valueRegex(R"((\w+)=([\d]+))");
-    QRegularExpression allocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+(.+)\s+\((.+):(\d+)\))");
+     QRegularExpression detailedAllocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+([\w:<>~]+)\s+\(([^:]+):(\d+)\))");
+    QRegularExpression summaryAllocRegex(R"(n\d+:\s+(\d+)\s+\(.+\))");
 
     QTextStream in(&file);
     while (!in.atEnd()) {
         QString line = in.readLine();
         QRegularExpressionMatch match;
 
-        if (line.contains(headerRegex, &match)) {
+        if (line.trimmed().startsWith("n")) {
+            QRegularExpression detailedAllocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+(.+)\s+\((.+):(\d+)\))");
+            // (npr. "n1: 4000 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.")
+            QRegularExpression summaryAllocRegex(R"(n\d+:\s+(\d+)\s+\(.+\))");
+
+            QRegularExpressionMatch match;
+
+            if ((match = detailedAllocRegex.match(line)).hasMatch()) {
+                AllocationEntry entry;
+                entry.bytes = match.captured(1).toLongLong();
+                entry.function = match.captured(2);
+                entry.sourceFile = match.captured(3);
+                entry.line = match.captured(4).toInt();
+
+                std::cout << entry.bytes << " bytes, " << entry.function.toStdString()
+                          << " " << entry.sourceFile.toStdString() << ":" << entry.line << std::endl;
+
+                snapshot.allocations.append(entry);
+            }
+            else if ((match = summaryAllocRegex.match(line)).hasMatch()) {
+                AllocationEntry entry;
+                entry.bytes = match.captured(1).toLongLong();
+                entry.function = "(summary)";
+                entry.sourceFile = "";
+                entry.line = 0;
+
+                std::cout << entry.bytes << " bytes, summary allocation line" << std::endl;
+
+                snapshot.allocations.append(entry);
+            }
+            else {
+                qDebug() << "Failed to match allocation line:" << line;
+            }
+        }
+        else if (line.contains(headerRegex, &match)) {
             header[match.captured(1)] = match.captured(2);
         }
         else if (line.contains(snapshotRegex, &match)) {
@@ -47,18 +83,7 @@ std::pair<QMap<QString, QString>, QVector<Snapshot>> Parser::parseMassifFile(con
             else if (key == "mem_heap_extra_B") snapshot.mem_heap_extra_B = value;
             else if (key == "mem_stacks_B") snapshot.mem_stacks_B = value;
         }
-        else if (line.startsWith("n")){
-            QRegularExpressionMatch allocMatch = allocRegex.match(line);
-            if (allocMatch.hasMatch()){
-                AllocationEntry entry;
-                entry.bytes = allocMatch.captured(1).toLongLong();
-                entry.function = allocMatch.captured(2);
-                entry.sourceFile = allocMatch.captured(3);
-                entry.line = allocMatch.captured(4).toInt();
 
-                snapshot.allocations.append(entry);
-            }
-        }
     }
 
     if (snapshot.snapshot >= 0) {

--- a/QT_Massif_App/Parser.cpp
+++ b/QT_Massif_App/Parser.cpp
@@ -22,7 +22,7 @@ std::pair<QMap<QString, QString>, QVector<Snapshot>> Parser::parseMassifFile(con
     QRegularExpression headerRegex(R"((\w+):\s*(.+))");
     QRegularExpression snapshotRegex(R"(snapshot=(\d+))");
     QRegularExpression valueRegex(R"((\w+)=([\d]+))");
-     QRegularExpression detailedAllocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+([\w:<>~]+)\s+\(([^:]+):(\d+)\))");
+    QRegularExpression detailedAllocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+([\w:<>~]+)\s+\(([^:]+):(\d+)\))");
     QRegularExpression summaryAllocRegex(R"(n\d+:\s+(\d+)\s+\(.+\))");
 
     QTextStream in(&file);

--- a/QT_Massif_App/Parser.cpp
+++ b/QT_Massif_App/Parser.cpp
@@ -34,7 +34,7 @@ std::pair<QMap<QString, QString>, QVector<Snapshot>> Parser::parseMassifFile(con
             QRegularExpression detailedAllocRegex(R"(n\d+:\s+(\d+)\s+0x[0-9A-Fa-f]+:\s+(.+)\s+\((.+):(\d+)\))");
             // (npr. "n1: 4000 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.")
             QRegularExpression summaryAllocRegex(R"(n\d+:\s+(\d+)\s+\(.+\))");
-            static QRegularExpression stdlibFunctionRegex(R"(^(std::|__|_Z|boost::))");
+            static QRegularExpression stdlibFunctionRegex(R"(^(std::|__gnu_cxx::|boost::|__|_Z|_IO_|_dl_|call_init|construct<|operator new|operator delete))");
 
             QRegularExpressionMatch match;
 

--- a/QT_Massif_App/Parser.h
+++ b/QT_Massif_App/Parser.h
@@ -6,12 +6,14 @@
 #include <QMap>
 #include <QVector>
 #include <QString>
+#include "functionallocsummary.h"
 
 class Parser
 {
 public:
     Parser();
     std::pair<QMap<QString, QString>, QVector<Snapshot>> parseMassifFile(const QString &filePath);
+    QMap<QString, FunctionAllocSummary> summarizeAllocationsByFunction(const QVector<Snapshot>& snapshots);
 };
 
 #endif // PARSER_H

--- a/QT_Massif_App/Snapshot.h
+++ b/QT_Massif_App/Snapshot.h
@@ -1,12 +1,17 @@
 #ifndef SNAPSHOT_H
 #define SNAPSHOT_H
 
+#include <QVector>
+#include "AllocationEntry.h"
+
 struct Snapshot{
     int snapshot;
     long time;
     long mem_heap_B;
     long mem_heap_extra_B;
     long mem_stacks_B;
+
+    QVector<AllocationEntry> allocations; //new field for detailed allocations
 };
 
 #endif // SNAPSHOT_H

--- a/QT_Massif_App/fileselector.h
+++ b/QT_Massif_App/fileselector.h
@@ -18,6 +18,8 @@ public:
 
     inline QString getFileName() const { return this->fileName; };
     inline QString getFilePath() const { return this->filePath; };
+    inline void setFileName(QString name) { fileName = name; }
+    inline void setFilePath(QString path) { filePath = path; }
     inline QString getOutFileName() const {return this->outFileName;};
     inline QString getOutFilePath() const {return this->outFilePath;};
 

--- a/QT_Massif_App/functionallocsummary.h
+++ b/QT_Massif_App/functionallocsummary.h
@@ -1,0 +1,13 @@
+#ifndef FUNCTIONALLOCSUMMARY_H
+#define FUNCTIONALLOCSUMMARY_H
+
+#include <QString>
+
+struct FunctionAllocSummary {
+    QString function;
+    qint64 totalBytes = 0;
+    int count = 0;
+};
+
+
+#endif // FUNCTIONALLOCSUMMARY_H

--- a/QT_Massif_App/mainwindow.cpp
+++ b/QT_Massif_App/mainwindow.cpp
@@ -60,11 +60,7 @@ void MainWindow::on_btExecute_clicked()
     }
 
     QString newMassifFilePath = massifRunner->getNextMassifOutFilePath();
-    massifRunner->runMassifCheck(*fileSelector, mode);
-
-    // this if is a temporary solution until automatic compilation is developed (not only for binary)
-    // should also refactor the runMassifCheck function so that it returns boolean = true if successful, so that can also be checked in the if
-    if(mode == BINARY){
+    if ( massifRunner->runMassifCheck(*fileSelector, mode) ){
         massifSelector->setFileFromPath(newMassifFilePath, OUTPUT);
         this->ui->leSelectedMassifOutFile->setText(QFileInfo(newMassifFilePath).fileName());
     }

--- a/QT_Massif_App/mainwindow.cpp
+++ b/QT_Massif_App/mainwindow.cpp
@@ -82,6 +82,10 @@ void MainWindow::setMassifOptions(MassifOptions *options)
     massifRunner->setMassifOptions(options);
 }
 
+void MainWindow::setMassifAnalyzerThresholds(MassifAnalyzerThresholds *thresholds){
+    massifRunner->setMassifAnalyzerThresholds(thresholds);
+}
+
 
 void MainWindow::on_btLoadMassifOutFile_clicked()
 {
@@ -107,4 +111,15 @@ void MainWindow::on_btShowResult_clicked()
     dialog.exec();
 }
 
+
+
+void MainWindow::on_btMassifAnalyzerParameters_clicked()
+{
+    MassifAnalyzerThresholdsWindow massifAnalyzerThresholdsWindow;
+    massifAnalyzerThresholdsWindow.setThresholdsFields(massifRunner->getThresholds());
+
+    QObject::connect(&massifAnalyzerThresholdsWindow, &MassifAnalyzerThresholdsWindow::thresholdsChanged, this, &MainWindow::setMassifAnalyzerThresholds);
+
+    massifAnalyzerThresholdsWindow.exec();
+}
 

--- a/QT_Massif_App/mainwindow.h
+++ b/QT_Massif_App/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include "massifrunner.h"
 #include "massifoptionswindow.h"
+#include "massifanalyzerthresholdswindow.h"
 #include "massifoptions.h"
 #include "fileselector.h"
 #include "massifanalyzer.h"
@@ -31,10 +32,13 @@ private slots:
 
     void on_btMassifOptions_clicked();
     void setMassifOptions(MassifOptions* options);
+    void setMassifAnalyzerThresholds(MassifAnalyzerThresholds *thresholds);
 
     void on_btLoadMassifOutFile_clicked();
 
     void on_btShowResult_clicked();
+
+    void on_btMassifAnalyzerParameters_clicked();
 
 private:
     Ui::MainWindow *ui;

--- a/QT_Massif_App/mainwindow.ui
+++ b/QT_Massif_App/mainwindow.ui
@@ -196,7 +196,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>410</y>
+      <y>420</y>
       <width>511</width>
       <height>29</height>
      </rect>
@@ -227,7 +227,7 @@
     <property name="geometry">
      <rect>
       <x>160</x>
-      <y>370</y>
+      <y>380</y>
       <width>371</width>
       <height>28</height>
      </rect>
@@ -251,7 +251,7 @@
     <property name="geometry">
      <rect>
       <x>0</x>
-      <y>330</y>
+      <y>340</y>
       <width>291</width>
       <height>29</height>
      </rect>
@@ -272,7 +272,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>370</y>
+      <y>380</y>
       <width>121</width>
       <height>29</height>
      </rect>
@@ -286,6 +286,29 @@
      <string>Load file</string>
     </property>
    </widget>
+   <widget class="QPushButton" name="btMassifAnalyzerParameters">
+    <property name="geometry">
+     <rect>
+      <x>470</x>
+      <y>330</y>
+      <width>40</width>
+      <height>40</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+    <property name="icon">
+     <iconset>
+      <normaloff>../../Resources/settings_icon.jpg</normaloff>../../Resources/settings_icon.jpg</iconset>
+    </property>
+    <property name="iconSize">
+     <size>
+      <width>30</width>
+      <height>30</height>
+     </size>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -293,7 +316,7 @@
      <x>0</x>
      <y>0</y>
      <width>552</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
   </widget>

--- a/QT_Massif_App/massifanalyzer.cpp
+++ b/QT_Massif_App/massifanalyzer.cpp
@@ -18,12 +18,12 @@ bool MassifAnalyzer::isMemoryStabilized(const QVector<Snapshot>& snapshots, int 
     return true;
 }
 
-QString MassifAnalyzer::detectMemoryLeaks(const QVector<Snapshot>& snapshots) {
-    const double MEMORY_JUMP_THRESHOLD = 0.5; // 50%
-    const qint64 LARGE_MEMORY_THRESHOLD = 1000000000; // 1 GB
+QString MassifAnalyzer::detectMemoryLeaks(const QVector<Snapshot>& snapshots, MassifAnalyzerThresholds *thresholds) {
+    const double MEMORY_JUMP_THRESHOLD = thresholds->memoryJumpThreshold; //0.5; // 50%
+    const qint64 LARGE_MEMORY_THRESHOLD = thresholds->largeMemoryThreshold; //1000000000; // 1 GB
     const qint64 BYTES_TO_MB = 1024 * 1024;
-    const qint64 MEMORY_FREE_THRESHOLD = 4 * 1024; // 4 KB
-    const double FRAGMENTATION_THRESHOLD = 0.10; // 10%
+    const qint64 MEMORY_FREE_THRESHOLD = thresholds->memoryFreeThreshold; //4 * 1024; // 4 KB
+    const double FRAGMENTATION_THRESHOLD = thresholds->fragmentationThreshold; //0.10; // 10%
 
     Snapshot previousSnapshot;
     bool hasPreviousSnapshot = false;
@@ -131,10 +131,10 @@ QString MassifAnalyzer::detectMemoryLeaks(const QVector<Snapshot>& snapshots) {
     return result;
 }
 
-QString MassifAnalyzer::generateFunctionAllocationReport(const QMap<QString, FunctionAllocSummary>& functionSummary) {
-    const qint64 HIGH_MEMORY_THRESHOLD = 100 * 1024 * 1024; // 100 MB
-    const int HIGH_ALLOCATION_COUNT = 10;
-    const qint64 SMALL_TOTAL_ALLOCATION = 5 * 1024 * 1024; // 5 MB
+QString MassifAnalyzer::generateFunctionAllocationReport(const QMap<QString, FunctionAllocSummary>& functionSummary, MassifAnalyzerThresholds *thresholds) {
+    const qint64 HIGH_MEMORY_THRESHOLD = thresholds->highMemoryThreshold; // 100 * 1024 * 1024; // 100 MB
+    const int HIGH_ALLOCATION_COUNT = thresholds->highAllocationCount; //10;
+    const qint64 SMALL_TOTAL_ALLOCATION = thresholds->smallTotalAllocation; //5 * 1024 * 1024; // 5 MB
 
     QString result;
 

--- a/QT_Massif_App/massifanalyzer.cpp
+++ b/QT_Massif_App/massifanalyzer.cpp
@@ -18,26 +18,6 @@ bool MassifAnalyzer::isMemoryStabilized(const QVector<Snapshot>& snapshots, int 
     return true;
 }
 
-QVector<FunctionAllocSummary> MassifAnalyzer::analyzeAllocationsPerFunction(const Snapshot& snapshot)
-{
-    QMap<QString, FunctionAllocSummary> summaryMap;
-    for (const AllocationEntry& entry: snapshot.allocations){
-        auto& summary = summaryMap[entry.function];
-        summary.function = entry.function;
-        summary.totalBytes += entry.bytes;
-        summary.count++;
-    }
-
-    QVector<FunctionAllocSummary> result = summaryMap.values();
-
-    // Sortiraj po veličini alokacije
-    std::sort(result.begin(), result.end(), [](const FunctionAllocSummary& a, const FunctionAllocSummary& b) {
-        return a.totalBytes > b.totalBytes;
-    });
-
-    return result;
-}
-
 QString MassifAnalyzer::detectMemoryLeaks(const QVector<Snapshot>& snapshots) {
     const double MEMORY_JUMP_THRESHOLD = 0.5; // 50%
     const qint64 LARGE_MEMORY_THRESHOLD = 1000000000; // 1 GB
@@ -120,7 +100,7 @@ QString MassifAnalyzer::detectMemoryLeaks(const QVector<Snapshot>& snapshots) {
             for (const AllocationEntry& alloc : snap.allocations) {
                 result += QString("%1 bytes in %2 at %3 : %4\n")
                               .arg(alloc.bytes)
-                              .arg(alloc.fu)
+                              .arg(alloc.function)
                               .arg(alloc.sourceFile)
                               .arg(alloc.line);
             }

--- a/QT_Massif_App/massifanalyzer.h
+++ b/QT_Massif_App/massifanalyzer.h
@@ -5,6 +5,8 @@
 #include <QObject>
 #include <QVector>
 #include "snapshot.h"
+#include <QMap>
+#include "functionallocsummary.h"
 
 class MassifAnalyzer
 {
@@ -12,6 +14,7 @@ public:
     MassifAnalyzer();
 
     bool isMemoryStabilized(const QVector<Snapshot>& snapshots, int currentIndex, int windowSize = 3);
+    QVector<FunctionAllocSummary> analyzeAllocationsPerFunction(const Snapshot& snapshot);
     QString detectMemoryLeaks(const QVector<Snapshot>& snapshots);
 };
 

--- a/QT_Massif_App/massifanalyzer.h
+++ b/QT_Massif_App/massifanalyzer.h
@@ -16,6 +16,7 @@ public:
     bool isMemoryStabilized(const QVector<Snapshot>& snapshots, int currentIndex, int windowSize = 3);
     QVector<FunctionAllocSummary> analyzeAllocationsPerFunction(const Snapshot& snapshot);
     QString detectMemoryLeaks(const QVector<Snapshot>& snapshots);
+    QString generateFunctionAllocationReport(const QMap<QString, FunctionAllocSummary>& functionSummary);
 };
 
 #endif // MASSIFANALYZER_H

--- a/QT_Massif_App/massifanalyzer.h
+++ b/QT_Massif_App/massifanalyzer.h
@@ -7,6 +7,7 @@
 #include "snapshot.h"
 #include <QMap>
 #include "functionallocsummary.h"
+#include "massifanalyzerthresholds.h"
 
 class MassifAnalyzer
 {
@@ -15,8 +16,8 @@ public:
 
     bool isMemoryStabilized(const QVector<Snapshot>& snapshots, int currentIndex, int windowSize = 3);
     QVector<FunctionAllocSummary> analyzeAllocationsPerFunction(const Snapshot& snapshot);
-    QString detectMemoryLeaks(const QVector<Snapshot>& snapshots);
-    QString generateFunctionAllocationReport(const QMap<QString, FunctionAllocSummary>& functionSummary);
+    QString detectMemoryLeaks(const QVector<Snapshot>& snapshots, MassifAnalyzerThresholds *thresholds);
+    QString generateFunctionAllocationReport(const QMap<QString, FunctionAllocSummary>& functionSummary, MassifAnalyzerThresholds *thresholds);
 };
 
 #endif // MASSIFANALYZER_H

--- a/QT_Massif_App/massifanalyzerthresholds.cpp
+++ b/QT_Massif_App/massifanalyzerthresholds.cpp
@@ -1,0 +1,27 @@
+#include "massifanalyzerthresholds.h"
+
+MassifAnalyzerThresholds::MassifAnalyzerThresholds(QObject *parent)
+    : QObject{parent}
+{}
+
+MassifAnalyzerThresholds::MassifAnalyzerThresholds(QObject *parent, MassifAnalyzerThresholds* thresholds)
+    : QObject{parent}
+    , highMemoryThreshold(thresholds->highMemoryThreshold)
+    , highAllocationCount(thresholds->highAllocationCount)
+    , smallTotalAllocation(thresholds->smallTotalAllocation)
+    , memoryFreeThreshold(thresholds->memoryFreeThreshold)
+    , memoryJumpThreshold(thresholds->memoryJumpThreshold)
+    , largeMemoryThreshold(thresholds->largeMemoryThreshold)
+    , fragmentationThreshold(thresholds->fragmentationThreshold)
+{}
+
+void MassifAnalyzerThresholds::setThresholds(MassifAnalyzerThresholds *thresholds)
+{
+    highMemoryThreshold = thresholds->highMemoryThreshold;
+    highAllocationCount = thresholds->highAllocationCount;
+    smallTotalAllocation = thresholds->smallTotalAllocation;
+    memoryJumpThreshold = thresholds->memoryJumpThreshold;
+    largeMemoryThreshold = thresholds->largeMemoryThreshold;
+    memoryFreeThreshold = thresholds->memoryFreeThreshold;
+    fragmentationThreshold = thresholds->fragmentationThreshold;
+}

--- a/QT_Massif_App/massifanalyzerthresholdswindow.cpp
+++ b/QT_Massif_App/massifanalyzerthresholdswindow.cpp
@@ -1,0 +1,40 @@
+#include "massifanalyzerthresholdswindow.h"
+#include "ui_massifanalyzerthresholdswindow.h"
+
+MassifAnalyzerThresholdsWindow::MassifAnalyzerThresholdsWindow(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::MassifAnalyzerThresholdsWindow)
+{
+    ui->setupUi(this);
+}
+
+void MassifAnalyzerThresholdsWindow::setThresholdsFields(MassifAnalyzerThresholds *thresholds)
+{
+    ui->sbFragmentationThreshold->setValue(thresholds->fragmentationThreshold * 100);
+    ui->sbHighAllocationCount->setValue(thresholds->highAllocationCount);
+    ui->sbHighMemoryThreshold->setValue(thresholds->highMemoryThreshold / BYTES_TO_MB);
+    ui->sbLargeMemoryThreshold->setValue(thresholds->largeMemoryThreshold / BYTES_TO_MB);
+    ui->sbMemoryFreeThreshold->setValue(thresholds->memoryFreeThreshold);
+    ui->sbMemoryJumpThreshold->setValue(thresholds->memoryJumpThreshold * 100);
+    ui->sbSmallTotalAllocation->setValue(thresholds->smallTotalAllocation / BYTES_TO_MB);
+}
+
+MassifAnalyzerThresholdsWindow::~MassifAnalyzerThresholdsWindow()
+{
+    delete ui;
+}
+
+void MassifAnalyzerThresholdsWindow::on_buttonBox_accepted()
+{
+    auto massifAnalyzerThresholds = new MassifAnalyzerThresholds();
+    massifAnalyzerThresholds->fragmentationThreshold = ui->sbFragmentationThreshold->text().toDouble() / 100;
+    massifAnalyzerThresholds->highAllocationCount = ui->sbHighAllocationCount->text().toInt();
+    massifAnalyzerThresholds->highMemoryThreshold = ui->sbHighMemoryThreshold->text().toLongLong() * BYTES_TO_MB;
+    massifAnalyzerThresholds->largeMemoryThreshold = ui->sbLargeMemoryThreshold->text().toLongLong() * BYTES_TO_MB;
+    massifAnalyzerThresholds->memoryFreeThreshold = ui->sbMemoryFreeThreshold->text().toLongLong();
+    massifAnalyzerThresholds->memoryJumpThreshold = ui->sbMemoryJumpThreshold->text().toDouble() / 100;
+    massifAnalyzerThresholds->smallTotalAllocation = ui->sbSmallTotalAllocation->text().toLongLong() * BYTES_TO_MB;
+
+    emit thresholdsChanged(massifAnalyzerThresholds);
+}
+

--- a/QT_Massif_App/massifanalyzerthresholdswindow.h
+++ b/QT_Massif_App/massifanalyzerthresholdswindow.h
@@ -1,0 +1,30 @@
+#ifndef MASSIFANALYZERTHRESHOLDSWINDOW_H
+#define MASSIFANALYZERTHRESHOLDSWINDOW_H
+
+#include <QDialog>
+#include "massifanalyzerthresholds.h"
+
+namespace Ui {
+class MassifAnalyzerThresholdsWindow;
+}
+
+class MassifAnalyzerThresholdsWindow : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit MassifAnalyzerThresholdsWindow(QWidget *parent = nullptr);
+    ~MassifAnalyzerThresholdsWindow();
+
+    void setThresholdsFields(MassifAnalyzerThresholds *thresholds);
+
+private slots:
+    void on_buttonBox_accepted();
+
+signals:
+    void thresholdsChanged(MassifAnalyzerThresholds *thresholds);
+private:
+    Ui::MassifAnalyzerThresholdsWindow *ui;
+};
+
+#endif // MASSIFANALYZERTHRESHOLDSWINDOW_H

--- a/QT_Massif_App/massifanalyzerthresholdswindow.ui
+++ b/QT_Massif_App/massifanalyzerthresholdswindow.ui
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MassifAnalyzerThresholdsWindow</class>
+ <widget class="QDialog" name="MassifAnalyzerThresholdsWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>525</width>
+    <height>559</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>510</y>
+     <width>341</width>
+     <height>33</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Orientation::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbHighMemoryThreshold">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>30</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>100</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbHighMemoryThreshold">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>30</y>
+     <width>271</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>High function memory threshold (MB)</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbHighAllocationCount">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>70</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>10</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbHighAllocationCount">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>70</y>
+     <width>301</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>High allocation count</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbSmallTotalAllocation">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>110</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>5</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbSmallTotalAllocation">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>110</y>
+     <width>261</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>Small function total allocation (MB)</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbMemoryJumpThreshold">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>150</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>50</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbMemoryJumpThreshold">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>150</y>
+     <width>261</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>Memory jump threshold (%)</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbLargeMemoryThreshold">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>190</y>
+     <width>301</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>Large memory threshold (MB)</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbFragmentationThreshold">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>270</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>10</number>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbLargeMemoryThreshold">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>190</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>1000</number>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="sbMemoryFreeThreshold">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>230</y>
+     <width>181</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignCenter</set>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>4096</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbFragmentationThreshold">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>270</y>
+     <width>261</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>Fragmentation threshold (%)</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lbMemoryFreeThreshold">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>230</y>
+     <width>261</width>
+     <height>29</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="lineWidth">
+    <number>0</number>
+   </property>
+   <property name="text">
+    <string>Memory free threshold </string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>MassifAnalyzerThresholdsWindow</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>MassifAnalyzerThresholdsWindow</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/QT_Massif_App/massifoptions.cpp
+++ b/QT_Massif_App/massifoptions.cpp
@@ -21,6 +21,9 @@ QString MassifOptions::makeAdditionalArguments()
 
     aditionalArguments += "--max-snapshots=" + std::to_string(maxSnapshots) + " ";
 
+    //adding this because we want to analyze every snapshot and make suggestions based on the informations
+    aditionalArguments += "--detailed-freq=1 --alloc-fn=yes ";
+
     return aditionalArguments;
 }
 

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -107,6 +107,12 @@ QString MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {
 
     MassifAnalyzer analyzer;
     QString text = analyzer.detectMemoryLeaks(snapshots);
+    auto functionSummary = parser.summarizeAllocationsByFunction(snapshots);
+
+    for (const auto& summary : functionSummary) {
+        qDebug() << summary.function << "allocated" << summary.totalBytes << "bytes in"
+                 << summary.count << "entries.";
+    }
 
     QMessageBox::information(nullptr, "Analysis", "Memory analysis completed. Press OK for results.");
     return text;

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -108,11 +108,7 @@ QString MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {
     MassifAnalyzer analyzer;
     QString text = analyzer.detectMemoryLeaks(snapshots);
     auto functionSummary = parser.summarizeAllocationsByFunction(snapshots);
-
-    for (const auto& summary : functionSummary) {
-        qDebug() << summary.function << "allocated" << summary.totalBytes << "bytes in"
-                 << summary.count << "entries.";
-    }
+    text += "\n" + analyzer.generateFunctionAllocationReport(functionSummary);
 
     QMessageBox::information(nullptr, "Analysis", "Memory analysis completed. Press OK for results.");
     return text;

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -50,7 +50,7 @@ QString MassifRunner::getMassifFilesDir() {
     return massifPath;
 }
 
-void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
+bool MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
     args.clear();
 
     if ( mode == COMPILE ){
@@ -69,8 +69,12 @@ void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
         QMessageBox msgBox;
         msgBox.setText("Compile finished!");
         msgBox.exec();
+
+        fileSelector.setFileName(fileSelector.getOutFileName());
+        fileSelector.setFilePath(fileSelector.getOutFilePath() + fileSelector.getOutFileName());
+        mode = BINARY;
     }
-    else if ( mode == BINARY){
+    if ( mode == BINARY){
         QString massifOut = convertWindowsPathToWsl(getNextMassifOutFilePath());
         QString exePath = convertWindowsPathToWsl(fileSelector.getFilePath());
 
@@ -85,8 +89,11 @@ void MassifRunner::runMassifCheck(FileSelector& fileSelector, Mode mode){
         bool started = QProcess::startDetached("cmd.exe", args);
         if (!started) {
             QMessageBox::warning(nullptr, "Error", "Failed to launch Valgrind in terminal.");
+            return false;
         }
     }
+
+    return true;
 }
 
 QString MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {

--- a/QT_Massif_App/massifrunner.cpp
+++ b/QT_Massif_App/massifrunner.cpp
@@ -7,6 +7,7 @@ MassifRunner::MassifRunner(QObject *parent)
     : QObject{parent}
     , process(new QProcess(this))
     , massifOptions(new MassifOptions(this))
+    , massifAnalyzerThresholds(new MassifAnalyzerThresholds(this))
 {}
 
 MassifRunner::~MassifRunner() = default;
@@ -106,9 +107,9 @@ QString MassifRunner::runMassifOutputAnalysis(FileSelector& fileSelector) {
     }
 
     MassifAnalyzer analyzer;
-    QString text = analyzer.detectMemoryLeaks(snapshots);
+    QString text = analyzer.detectMemoryLeaks(snapshots, this->massifAnalyzerThresholds);
     auto functionSummary = parser.summarizeAllocationsByFunction(snapshots);
-    text += "\n" + analyzer.generateFunctionAllocationReport(functionSummary);
+    text += "\n" + analyzer.generateFunctionAllocationReport(functionSummary, this->massifAnalyzerThresholds);
 
     QMessageBox::information(nullptr, "Analysis", "Memory analysis completed. Press OK for results.");
     return text;
@@ -173,4 +174,9 @@ void MassifRunner::setMassifOptions(MassifOptions *options)
     massifOptions->includeStackProfiling = options->includeStackProfiling;
     massifOptions->timeUnit = options->timeUnit;
     massifOptions->maxSnapshots = options->maxSnapshots;
+}
+
+void MassifRunner::setMassifAnalyzerThresholds(MassifAnalyzerThresholds *thresholds){
+    this->massifAnalyzerThresholds->setThresholds(thresholds);
+    delete(thresholds);
 }

--- a/QT_Massif_App/massifrunner.h
+++ b/QT_Massif_App/massifrunner.h
@@ -30,7 +30,7 @@ public:
 
     QString convertWindowsPathToWsl(const QString& winPath);
     QString getMassifFilesDir();
-    void runMassifCheck(FileSelector& fileSelector, Mode mode);
+    bool runMassifCheck(FileSelector& fileSelector, Mode mode);
     QString getNextMassifOutFilePath();
     void setMassifOptions(MassifOptions* options);
     QString runMassifOutputAnalysis(FileSelector& fileSelector);

--- a/QT_Massif_App/massifrunner.h
+++ b/QT_Massif_App/massifrunner.h
@@ -13,6 +13,7 @@
 #include "fileselector.h"
 #include "massifanalyzer.h"
 #include "massifoptions.h"
+#include "massifanalyzerthresholds.h"
 
 
 class MassifRunner : public QObject
@@ -24,8 +25,8 @@ public:
 
     QProcess *process;
 
-    inline QStringList getArgs() {return this->args; };
-    inline void addArg(QString arg) { args << arg; };
+    inline QStringList getArgs() {return this->args; }
+    inline void addArg(QString arg) { args << arg; }
 
 
     QString convertWindowsPathToWsl(const QString& winPath);
@@ -33,8 +34,11 @@ public:
     bool runMassifCheck(FileSelector& fileSelector, Mode mode);
     QString getNextMassifOutFilePath();
     void setMassifOptions(MassifOptions* options);
+    void setMassifAnalyzerThresholds(MassifAnalyzerThresholds *thresholds);
     QString runMassifOutputAnalysis(FileSelector& fileSelector);
     QString MassifGraphUsingMsPrint(const FileSelector& massifSelector);
+
+    inline MassifAnalyzerThresholds* getThresholds(){return massifAnalyzerThresholds;}
 
 private:
     Mode mode = COMPILE;
@@ -42,8 +46,8 @@ private:
     QStringList args;
 
     MassifOptions* massifOptions;
+    MassifAnalyzerThresholds* massifAnalyzerThresholds;
 
-signals:
 };
 
 #endif // MASSIFRUNNER_H

--- a/run_massif_on_tests.sh
+++ b/run_massif_on_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEST_DIR="test"
-TEST_FILES=("test1.c" "test2.c" "test3.cpp" "test4.cpp")
+TEST_FILES=("test1.c" "test2.c" "test3.cpp" "test4.cpp" "test5.cpp")
 OUTPUT_DIR="massif_files"
 OUTPUT_FILE_BASE="massif.out"
 

--- a/run_massif_on_tests.sh
+++ b/run_massif_on_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEST_DIR="test"
-TEST_FILES=("test1.c" "test2.c" "test3.cpp")
+TEST_FILES=("test1.c" "test2.c" "test3.cpp" "test4.cpp")
 OUTPUT_DIR="massif_files"
 OUTPUT_FILE_BASE="massif.out"
 

--- a/test/README.md
+++ b/test/README.md
@@ -45,3 +45,13 @@ This test case demonstrates a common memory management issue where a fixed-size 
 The massif graph shows a generally increasing trend in memory usage as the internal buffer fills up with log entries that are never removed. The gradual upward slope corresponds to continuous allocation without deallocation, reflecting the accumulation of messages. Occasional drops in the graph represent the points where the flush() method is called, clearing the buffer and releasing memory temporarily. However, the overall trend remains upward due to the absence of old message removal during logging, highlighting potential memory inefficiency.
 
 ![Image](https://github.com/user-attachments/assets/9f185c9f-c0df-42af-a27a-851d8a18cd68)
+
+## Test Case 4: `massif.out.4`
+
+**Purpose**:
+This test case is designed to simulate memory fragmentation by performing many small heap allocations with varying lifetimes and without proper reuse or compaction of freed memory. The goal is to trigger the fragmentation warning by increasing mem_heap_extra_B relative to mem_heap_B, representing inefficient use of heap space.
+
+**Graph Explanation**:
+The massif graph may not show a steep increase in total memory usage (`mem_heap_B`), but the internal metric `mem_heap_extra_B` grows significantly. This indicates that although not much memory is actively used by the program, a large portion of the heap remains unusable due to fragmentation. The analyzer detects this by comparing the ratio of `mem_heap_extra_B` to `mem_heap_B`, and if it exceeds a threshold (e.g., 10%), it issues a warning about possible fragmentation. This reflects a situation where freed memory cannot be reused efficiently, often caused by patterns of allocating and freeing blocks of different sizes and lifetimes.
+
+![test4](https://github.com/user-attachments/assets/acf13781-bba2-4318-b885-3f70e6fc4906)

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ valgrind --tool=massif --massif-out-file=massif.out.1 ./program
 
 In this section, we describe different test cases that were used to analyze memory usage. The memory usage data is captured using Massif and visualized through graphs. Screenshots of these graphs are included below for clarity.
 
-## Test Case 1: `massif.out.1`
+## Test Case 1: `massif.out.0`
 
 **Purpose**: This test case is used to simulate a scenario where memory usage is relatively stable. The graph shows memory consumption over time, with specific points where the memory usage increases gradually, eventually stabilizing.
 
@@ -26,7 +26,7 @@ The graph below shows memory usage (in KB) over the course of the program's exec
 ![Screenshot from 2025-01-03 23-59-53](https://github.com/user-attachments/assets/9bd2a3f3-4b4f-4835-9c24-a7c6f5874d41)
 
 
-## Test Case 2: `massif.out.2`
+## Test Case 2: `massif.out.1`
 
 **Purpose**: This test case is designed to simulate scenarios with sudden spikes in memory usage, allowing us to test the functionality of detecting abrupt jumps in memory consumption.
 
@@ -36,7 +36,7 @@ In this graph, the vertical spikes represent sudden increases in memory usage. T
 
 ![Screenshot from 2025-01-04 00-00-44](https://github.com/user-attachments/assets/adb07cd0-e2fd-47f9-b58c-ca72f99d3c04)
 
-## Test Case 3: `massif.out.3`
+## Test Case 3: `massif.out.2`
 
 **Purpose**:
 This test case demonstrates a common memory management issue where a fixed-size buffer continuously accumulates data without removing old entries, simulating a memory leak or unbounded growth scenario. The goal is to analyze how memory usage grows steadily over time when old data is not properly discarded, and to identify the impact of periodic clearing (flush) on memory consumption.
@@ -46,7 +46,7 @@ The massif graph shows a generally increasing trend in memory usage as the inter
 
 ![Image](https://github.com/user-attachments/assets/9f185c9f-c0df-42af-a27a-851d8a18cd68)
 
-## Test Case 4: `massif.out.4`
+## Test Case 4: `massif.out.3`
 
 **Purpose**:
 This test case is designed to simulate memory fragmentation by performing many small heap allocations with varying lifetimes and without proper reuse or compaction of freed memory. The goal is to trigger the fragmentation warning by increasing mem_heap_extra_B relative to mem_heap_B, representing inefficient use of heap space.
@@ -55,3 +55,13 @@ This test case is designed to simulate memory fragmentation by performing many s
 The massif graph may not show a steep increase in total memory usage (`mem_heap_B`), but the internal metric `mem_heap_extra_B` grows significantly. This indicates that although not much memory is actively used by the program, a large portion of the heap remains unusable due to fragmentation. The analyzer detects this by comparing the ratio of `mem_heap_extra_B` to `mem_heap_B`, and if it exceeds a threshold (e.g., 10%), it issues a warning about possible fragmentation. This reflects a situation where freed memory cannot be reused efficiently, often caused by patterns of allocating and freeing blocks of different sizes and lifetimes.
 
 ![test4](https://github.com/user-attachments/assets/acf13781-bba2-4318-b885-3f70e6fc4906)
+
+## Test Case 5: `massif.out.4`
+
+**Purpose**:
+This test case combines different allocation patterns to demonstrate their cumulative effect on memory usage. It includes one very large allocation (150 MB), many small individual allocations (1500 ints), and a large number of moderate-sized allocations (2000 strings of 1 KB each). The goal is to trigger warnings for both large and frequent allocations, illustrating how different allocation behaviors contribute to total memory consumption.
+
+**Graph Explanation**:
+The massif graph shows a sudden large spike in memory usage early in the run, reflecting the combined effect of all allocations made by the program. Rather than multiple smaller increases, memory usage jumps rapidly to a high level and stays roughly constant until near program termination. This “rectangular” shape results from the large allocation alongside the many smaller allocations, all held live simultaneously, causing total heap usage to remain elevated throughout execution.
+
+![test5](https://github.com/user-attachments/assets/496d3005-92bc-47cb-9027-c439174a80b0)

--- a/test/test4.cpp
+++ b/test/test4.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <vector>
+#include <cstdlib>
+
+int main() {
+    std::vector<void*> allocations;
+
+
+    for (int i = 0; i < 10000; ++i) {
+        allocations.push_back(malloc(32));
+    }
+
+
+    for (int i = 0; i < 10000; i += 2) {
+        free(allocations[i]);
+        allocations[i] = nullptr;
+    }
+
+    std::cout << "Finished allocations and frees. Check your massif snapshot now." << std::endl;
+
+    std::cout << "Press Enter to exit...";
+    std::cin.get();
+
+
+    for (void* ptr : allocations) {
+        if (ptr) free(ptr);
+    }
+
+    return 0;
+}

--- a/test/test5.cpp
+++ b/test/test5.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <vector>
+#include <string>
+
+void largeAllocator() {
+    // Allocates over 100 MB -> should trigger "Warning: large memory allocation"
+    std::vector<char> bigBlock(150 * 1024 * 1024); // 150 MB
+}
+
+void manySmallAllocations() {
+    std::vector<int*> ptrs;
+    for (int i = 0; i < 1500; ++i) {
+        ptrs.push_back(new int(i)); // svaka iteracija pravi novu malloc alokaciju
+    }
+}
+
+void bothHeavyAndFrequent() {
+    // Allocates frequently and with large total size -> triggers both warnings and notes
+    std::vector<std::string> heavy;
+    for (int i = 0; i < 2000; ++i) {
+        heavy.emplace_back(std::string(1024, 'a')); // 1 KB * 2000 = 2 MB total, many allocations
+    }
+}
+
+void negligibleAllocator() {
+    // Allocates very little memory -> should not trigger any warning or note
+    std::string s = "hello world";
+}
+
+int main() {
+    largeAllocator();
+    manySmallAllocations();
+    bothHeavyAndFrequent();
+    negligibleAllocator();
+
+    return 0;
+}


### PR DESCRIPTION
## 🚀 Summary

This pull request introduces a significant set of improvements to the massif analysis tool, focused on **heuristic-based reporting**, **parameter configurability**, and **enhanced test support**.

---

## ✅ What's Implemented

### 🔎 Heuristic Warnings & Notes
- Added a set of **custom heuristics** that detect potential memory issues in massif outputs:
  - Large memory allocations
  - Many small allocations in one function
  - Many allocations in one function
  - Memory fragmentation
  - Negligible usage (low allocation)
- Warnings and notes are now displayed directly in the **report view**, instead of only in the console.

### ⚙️ Configurable Thresholds
- Introduced a `MassifAnalyzerThresholds` class to encapsulate all heuristic parameters (e.g., allocation size, fragmentation ratio).
- Default values are initialized on startup.
- Users can **dynamically configure thresholds** via the **Settings** button before viewing a report.
- These thresholds persist throughout the session and are reused unless changed manually.

### 🔁 Unified Action
- When the user selects the **first menu option**, the tool now:
  1. Compiles the selected C/C++ source file.
  2. Immediately runs the compiled binary using **Valgrind's Massif tool**.
- Eliminates the need to manually select "Run Massif" as a separate step after compiling.

### 🧠 User Experience Improvements
- Simplifies interaction flow for users analyzing individual test files.
- Reduces potential for errors by ensuring the correct binary is always used directly after compilation.

### 🧪 Test Integration
- Added `test5.cpp` as a composite test case that demonstrates the triggering of multiple heuristics simultaneously.
- Included a clear explanation of its memory behavior and corresponding massif graph.

### 📊 Function-Level Memory Breakdown
- Introduced `AllocEntry` and `FunctionAllocSummary` associated logic to map memory usage to individual functions.
- Enables function-level summaries of heap usage at the peak snapshot in the report.

---